### PR TITLE
Accepting DateTimeInterface for Date and DateTime Literals (foreign code by @madbob).

### DIFF
--- a/lib/Literal/Date.php
+++ b/lib/Literal/Date.php
@@ -36,6 +36,8 @@ namespace EasyRdf\Literal;
  * @copyright  Copyright (c) 2009-2014 Nicholas J Humfrey
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
+
+use DateTimeInterface;
 use EasyRdf\Literal;
 
 /**
@@ -50,7 +52,7 @@ class Date extends Literal
 {
     /** Constructor for creating a new date literal
      *
-     * If the value is a DateTime object, then it will be converted to the xsd:date format.
+     * If the value is a DateTimeInterface object, then it will be converted to the xsd:date format.
      * If no value is given or is is null, then the current date is used.
      *
      * @see \DateTime
@@ -72,8 +74,8 @@ class Date extends Literal
             $value = new \DateTime('today');
         }
 
-        // Convert DateTime object into string
-        if ($value instanceof \DateTime) {
+        // Convert DateTimeInterface object into string
+        if ($value instanceof DateTimeInterface) {
             $value = $value->format('Y-m-d');
         }
 

--- a/lib/Literal/DateTime.php
+++ b/lib/Literal/DateTime.php
@@ -2,6 +2,8 @@
 
 namespace EasyRdf\Literal;
 
+use DateTimeInterface;
+
 /*
  * EasyRdf
  *
@@ -36,7 +38,6 @@ namespace EasyRdf\Literal;
  * @copyright  Copyright (c) 2009-2014 Nicholas J Humfrey
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
-use EasyRdf\Literal;
 
 /**
  * Class that represents an RDF Literal of datatype xsd:dateTime
@@ -50,7 +51,7 @@ class DateTime extends Date
 {
     /** Constructor for creating a new date and time literal
      *
-     * If the value is a DateTime object, then it will be converted to the xsd:dateTime format.
+     * If the value is a DateTimeInterface object, then it will be converted to the xsd:dateTime format.
      * If no value is given or is is null, then the current time is used.
      *
      * @see \DateTime
@@ -73,8 +74,8 @@ class DateTime extends Date
         }
 
         // Convert DateTime objects into string
-        if ($value instanceof \DateTime) {
-            $atom = $value->format(\DateTime::ATOM);
+        if ($value instanceof DateTimeInterface) {
+            $atom = $value->format(DateTimeInterface::ATOM);
             $value = preg_replace('/[\+\-]00(\:?)00$/', 'Z', $atom);
         }
 

--- a/lib/Literal/DateTime.php
+++ b/lib/Literal/DateTime.php
@@ -74,7 +74,11 @@ class DateTime extends Date
         }
 
         // workaround for PHP < 7.2: if not used, script will throw "Undefined class constant 'ATOM'"
-        $format = DateTimeInterface::ATOM ?? \DateTime::ATOM;
+        if (defined('\DateTimeInterface::ATOM')) {
+            $format = DateTimeInterface::ATOM;
+        } else {
+            $format = \DateTime::ATOM;
+        }
 
         // Convert DateTime objects into string
         if ($value instanceof DateTimeInterface) {

--- a/lib/Literal/DateTime.php
+++ b/lib/Literal/DateTime.php
@@ -74,7 +74,7 @@ class DateTime extends Date
         }
 
         // workaround for PHP < 7.2: if not used, script will throw "Undefined class constant 'ATOM'"
-        if (defined('\DateTimeInterface::ATOM')) {
+        if (\defined('\DateTimeInterface::ATOM')) {
             $format = DateTimeInterface::ATOM;
         } else {
             $format = \DateTime::ATOM;

--- a/lib/Literal/DateTime.php
+++ b/lib/Literal/DateTime.php
@@ -73,9 +73,12 @@ class DateTime extends Date
             $value = new \DateTime('now');
         }
 
+        // workaround for PHP < 7.2: if not used, script will throw "Undefined class constant 'ATOM'"
+        $format = DateTimeInterface::ATOM ?? \DateTime::ATOM;
+
         // Convert DateTime objects into string
         if ($value instanceof DateTimeInterface) {
-            $atom = $value->format(DateTimeInterface::ATOM);
+            $atom = $value->format($format);
             $value = preg_replace('/[\+\-]00(\:?)00$/', 'Z', $atom);
         }
 

--- a/test/EasyRdf/Literal/DateTest.php
+++ b/test/EasyRdf/Literal/DateTest.php
@@ -63,6 +63,17 @@ class DateTest extends TestCase
         $this->assertSame('xsd:date', $literal->getDatatype());
     }
 
+    public function testConstructFromDateTimeImmutable()
+    {
+        $dt = new \DateTimeImmutable('2011-07-18');
+        $literal = new Date($dt);
+        $this->assertStringEquals('2011-07-18', $literal);
+        $this->assertClass('DateTime', $literal->getValue());
+        $this->assertEquals($dt, $literal->getValue());
+        $this->assertStringEquals('', $literal->getLang());
+        $this->assertSame('xsd:date', $literal->getDatatype());
+    }
+
     public function testConstructNoValue()
     {
         // Would be very unlucky if this ran at midnight and failed

--- a/test/EasyRdf/Literal/DateTimeTest.php
+++ b/test/EasyRdf/Literal/DateTimeTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\EasyRdf\Literal;
 
+use DateTimeImmutable;
 use EasyRdf\Literal\DateTime;
 use Test\TestCase;
 
@@ -45,6 +46,11 @@ class DateTimeTest extends TestCase
     /** @var DateTime */
     private $dt;
 
+    protected function setUp()
+    {
+        $this->dt = new DateTime('2010-09-08T07:06:05Z');
+    }
+
     public function testConstruct()
     {
         $literal = new DateTime('2011-07-18T18:45:43Z');
@@ -84,6 +90,17 @@ class DateTimeTest extends TestCase
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
     }
 
+    public function testConstructFromDateTimeImmutableUTC()
+    {
+        $dt = new DateTimeImmutable('2010-09-08T07:06:05Z');
+        $literal = new DateTime($dt);
+        $this->assertStringEquals('2010-09-08T07:06:05Z', $literal);
+        $this->assertClass('DateTime', $literal->getValue());
+        $this->assertEquals($dt, $literal->getValue());
+        $this->assertStringEquals('', $literal->getLang());
+        $this->assertSame('xsd:dateTime', $literal->getDatatype());
+    }
+
     public function testParseUTC()
     {
         $literal = DateTime::parse('Mon 18 Jul 2011 18:45:43 UTC');
@@ -100,11 +117,6 @@ class DateTimeTest extends TestCase
         $this->assertClass('DateTime', $literal->getValue());
         $this->assertStringEquals('', $literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
-    }
-
-    protected function setUp()
-    {
-        $this->dt = new DateTime('2010-09-08T07:06:05Z');
     }
 
     public function testFormat()


### PR DESCRIPTION
@madbob: I found your pull request for EasyRdf with DateTimeInterface very useful and therefore cherry picked it for my fork.

Changes:
* Adapted tests because PHPStan complained about `assertNull` on `$literal->getLang()`. Replaced it with `assertStringEquals`.
* undefined class constant error for `\DateTimeInterface::ATOM` when using PHP 7.1 or below.