### PR TITLE
Bumb min. PHP version to 8.0.0 + cleanup (mostly PHP-CS-Fixer)

### DIFF
--- a/.github/workflows/CodingStyles.yml
+++ b/.github/workflows/CodingStyles.yml
@@ -11,7 +11,7 @@ jobs:
             fail-fast: true
             matrix:
                 php:
-                    - 7.4
+                    - 8.0
 
         steps:
             -   name: Checkout

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -54,4 +54,4 @@ jobs:
                 run: composer update --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
             -   name: Tests
-                run: vendor/bin/phpunit --exclude linux
+                run: vendor/bin/phpunit --exclude-group linux

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+                php-versions: ['8.0', '8.1', '8.2']
 
         steps:
             -   name: Checkout
@@ -38,7 +38,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+                php-versions: ['8.0', '8.1', '8.2']
 
         steps:
             -   name: Checkout

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,8 +13,10 @@ $finder = Finder::create()
 $config = new Config();
 $config
     ->setFinder($finder)
+    ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
+        '@Symfony:risky' => true,
         'phpdoc_summary' => false,
     ])
 ;

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ echo "My name is: ".$me->get('foaf:name')."\n";
 
 ## Requirements
 
-* PHP 7.1 or higher
+* PHP 8.0 or higher
 * PHP Extensions: dom, mbstring, pcre, xmlreader
 * PHP Libs: libxml
 

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         }
     ],
     "replace": {
-        "easyrdf/easyrdf":"1.0.*|1.1.*"
+        "easyrdf/easyrdf":"1.1.*"
     },
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0",
         "ext-dom" : "*",
         "ext-mbstring": "*",
         "ext-pcre": "*",
@@ -38,7 +38,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "ml/json-ld": "^1.0",
-        "phpunit/phpunit": "^7.5|^8.5|^9.5",
+        "phpunit/phpunit": "^9.5.0|^10.0.0",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "semsol/arc2": "^2.4",

--- a/examples/html_tag_helpers.php
+++ b/examples/html_tag_helpers.php
@@ -144,8 +144,8 @@ function password_field_tag($name = 'password', $default = null, $options = [])
 
 function radio_button_tag($name, $value, $default = false, $options = [])
 {
-    if ((isset($_REQUEST[$name]) && $_REQUEST[$name] == $value) ||
-        (!isset($_REQUEST[$name]) && $default)) {
+    if ((isset($_REQUEST[$name]) && $_REQUEST[$name] == $value)
+        || (!isset($_REQUEST[$name]) && $default)) {
         $options = array_merge(['checked' => 'checked'], $options);
     }
     $options = array_merge(['id' => $name.'_'.$value], $options);
@@ -155,8 +155,8 @@ function radio_button_tag($name, $value, $default = false, $options = [])
 
 function check_box_tag($name, $value = '1', $default = false, $options = [])
 {
-    if ((isset($_REQUEST[$name]) && $_REQUEST[$name] == $value) ||
-        (!isset($_REQUEST['submit']) && $default)) {
+    if ((isset($_REQUEST[$name]) && $_REQUEST[$name] == $value)
+        || (!isset($_REQUEST['submit']) && $default)) {
         $options = array_merge(['checked' => 'checked'], $options);
     }
 
@@ -196,8 +196,8 @@ function select_tag($name, $options, $default = null, $html_options = [])
     $opts = '';
     foreach ($options as $key => $value) {
         $arr = ['value' => $value];
-        if ((isset($_REQUEST[$name]) && $_REQUEST[$name] == $value) ||
-            (!isset($_REQUEST[$name]) && $default == $value)) {
+        if ((isset($_REQUEST[$name]) && $_REQUEST[$name] == $value)
+            || (!isset($_REQUEST[$name]) && $default == $value)) {
             $arr = array_merge(['selected' => 'selected'], $arr);
         }
         $opts .= content_tag('option', $key, $arr);

--- a/examples/index.php
+++ b/examples/index.php
@@ -13,9 +13,9 @@ if (!$dh) {
 
 $exampleList = [];
 while (($filename = readdir($dh)) !== false) {
-    if ('.' == substr($filename, 0, 1) ||
-        'index.php' == $filename ||
-        'html_tag_helpers.php' == $filename) {
+    if ('.' == substr($filename, 0, 1)
+        || 'index.php' == $filename
+        || 'html_tag_helpers.php' == $filename) {
         continue;
     }
 

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -51,12 +51,12 @@ class Format
     private static $formats = [];
 
     private $name = [];
-    private $label = null;
-    private $uri = null;
+    private $label;
+    private $uri;
     private $mimeTypes = [];
     private $extensions = [];
-    private $parserClass = null;
-    private $serialiserClass = null;
+    private $parserClass;
+    private $serialiserClass;
 
     /** Get a list of format names
      *
@@ -148,15 +148,15 @@ class Format
      */
     public static function getFormat($query)
     {
-        if (!is_string($query) || (is_string($query) && 0 == strlen($query))) {
+        if (!\is_string($query) || (\is_string($query) && 0 == \strlen($query))) {
             throw new \InvalidArgumentException('$query should be a string and cannot be null or empty');
         }
 
         foreach (self::$formats as $format) {
-            if ($query == $format->name ||
-                $query == $format->uri ||
-                \array_key_exists($query, $format->mimeTypes) ||
-                \in_array($query, $format->extensions)) {
+            if ($query == $format->name
+                || $query == $format->uri
+                || \array_key_exists($query, $format->mimeTypes)
+                || \in_array($query, $format->extensions)) {
                 return $format;
             }
         }
@@ -184,7 +184,7 @@ class Format
         $mimeTypes = [],
         $extensions = []
     ) {
-        if (!is_string($name) || (is_string($name) && 0 == strlen($name))) {
+        if (!\is_string($name) || (\is_string($name) && 0 == \strlen($name))) {
             throw new \InvalidArgumentException('$name should be a string and cannot be null or empty');
         }
 

--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -53,8 +53,8 @@ use EasyRdf\Http\Client;
 class Graph
 {
     /** The URI of the graph */
-    private $uri = null;
-    private $parsedUri = null;
+    private $uri;
+    private $parsedUri;
 
     /** Array of resources contained in the graph */
     private $resources = [];
@@ -185,9 +185,9 @@ class Graph
 
         // Parsers don't typically add a rdf:type to rdf:List, so we have to
         // do a bit of 'inference' here using properties.
-        if ('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil' == $uri ||
-            isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#first']) ||
-            isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'])
+        if ('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil' == $uri
+            || isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#first'])
+            || isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'])
         ) {
             return 'EasyRdf\Collection';
         }
@@ -308,7 +308,7 @@ class Graph
         $client->setMethod('GET');
 
         if ($format && 'guess' !== $format) {
-            if (false !== strpos($format, '/')) {
+            if (str_contains($format, '/')) {
                 if ($client instanceof Client) {
                     $client->setHeaders('Accept', $format);
                 } else {
@@ -443,8 +443,8 @@ class Graph
             if (isset($index[$subject][$property])) {
                 if (isset($value)) {
                     foreach ($this->index[$subject][$property] as $v) {
-                        if ($v['type'] == $value['type'] &&
-                            $v['value'] == $value['value']) {
+                        if ($v['type'] == $value['type']
+                            && $v['value'] == $value['value']) {
                             $matched[] = $this->resource($subject);
                             break;
                         }
@@ -1479,8 +1479,6 @@ class Graph
      * may be arbitrary.
      * This method will return null if the resource has no type.
      *
-     * @param mixed $resource
-     *
      * @return \EasyRdf\Resource|null A type associated with the resource
      */
     public function typeAsResource($resource = null)
@@ -1628,8 +1626,6 @@ class Graph
     }
 
     /** Get the primary topic of the graph
-     *
-     * @param mixed $resource
      *
      * @return \EasyRdf\Resource|null the primary topic of the document
      */

--- a/lib/GraphStore.php
+++ b/lib/GraphStore.php
@@ -51,8 +51,8 @@ class GraphStore
     public const DEFAULT_GRAPH = 'urn:easyrdf:default-graph';
 
     /** The address of the GraphStore endpoint */
-    private $uri = null;
-    private $parsedUri = null;
+    private $uri;
+    private $parsedUri;
 
     /** Create a new SPARQL Graph Store client
      *
@@ -292,7 +292,7 @@ class GraphStore
     {
         if (self::DEFAULT_GRAPH === $url) {
             $url = $this->uri.'?default';
-        } elseif (false === strpos($url, $this->uri)) {
+        } elseif (!str_contains($url, $this->uri)) {
             $url = $this->uri.'?graph='.urlencode($url);
         }
 

--- a/lib/Http.php
+++ b/lib/Http.php
@@ -49,7 +49,7 @@ class Http
      *
      * @var Http\Client|\Zend\Http\Client|\Laminas\Http\Client|null
      */
-    private static $defaultHttpClient = null;
+    private static $defaultHttpClient;
 
     /** Set the HTTP Client object used to fetch RDF data
      *

--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -67,7 +67,7 @@ class Client
      *
      * @var string
      */
-    private $uri = null;
+    private $uri;
 
     /**
      * Associative array of request headers
@@ -95,7 +95,7 @@ class Client
      *
      * @var string|null
      */
-    private $rawPostData = null;
+    private $rawPostData;
 
     /**
      * Redirection counter
@@ -489,8 +489,8 @@ class Client
             $response = Response::fromString($content);
 
             // If we got redirected, look for the Location header
-            if ($response->isRedirect() &&
-                   ($location = $response->getHeader('location'))
+            if ($response->isRedirect()
+                   && ($location = $response->getHeader('location'))
             ) {
                 // Avoid problems with buggy servers that add whitespace at the
                 // end of some headers (See ZF-11283)

--- a/lib/Isomorphic.php
+++ b/lib/Isomorphic.php
@@ -152,13 +152,11 @@ class Isomorphic
                     }
 
                     if ($subjectIsBnode || $objectIsBnode) {
-                            $anonStatements[] =
-                            [
-                                ['type' => $subjectIsBnode ? 'bnode' : 'uri', 'value' => $subject],
-                                ['type' => 'uri', 'value' => $property],
-                                $value,
-                            ]
-                        ;
+                        $anonStatements[] = [
+                            ['type' => $subjectIsBnode ? 'bnode' : 'uri', 'value' => $subject],
+                            ['type' => 'uri', 'value' => $property],
+                            $value,
+                        ];
                     }
                 }
             }

--- a/lib/Isomorphic.php
+++ b/lib/Isomorphic.php
@@ -143,23 +143,22 @@ class Isomorphic
                         $objectIsBnode = false;
                     }
 
-                    if ($groundedStatementsMatch &&
-                        false === $subjectIsBnode &&
-                        false === $objectIsBnode &&
-                        false === $graphB->hasProperty($subject, $property, $value)
+                    if ($groundedStatementsMatch
+                        && false === $subjectIsBnode
+                        && false === $objectIsBnode
+                        && false === $graphB->hasProperty($subject, $property, $value)
                     ) {
                         $groundedStatementsMatch = false;
                     }
 
                     if ($subjectIsBnode || $objectIsBnode) {
-                        array_push(
-                            $anonStatements,
+                            $anonStatements[] =
                             [
                                 ['type' => $subjectIsBnode ? 'bnode' : 'uri', 'value' => $subject],
                                 ['type' => 'uri', 'value' => $property],
                                 $value,
                             ]
-                        );
+                        ;
                     }
                 }
             }
@@ -383,9 +382,9 @@ class Isomorphic
         foreach ($statements as $statement) {
             if (\in_array($node, $statement)) {
                 foreach ($statement as $resource) {
-                    if ('bnode' != $node['type'] ||
-                        isset($hashes[$node['value']]) ||
-                        $resource == $node
+                    if ('bnode' != $node['type']
+                        || isset($hashes[$node['value']])
+                        || $resource == $node
                     ) {
                         $grounded = false;
                     }

--- a/lib/Literal.php
+++ b/lib/Literal.php
@@ -51,17 +51,17 @@ class Literal
     private static $classMap = [];
 
     /** @ignore The string value for this literal */
-    protected $value = null;
+    protected $value;
 
     /** @ignore The language of the literal (e.g. 'en') */
-    protected $lang = null;
+    protected $lang;
 
     /**
      * The datatype URI of the literal
      *
      * @var string|\EasyRdf\ParsedUri|null
      */
-    protected $datatype = null;
+    protected $datatype;
 
     /** Create a new literal object
      *
@@ -134,11 +134,11 @@ class Literal
      */
     public static function setDatatypeMapping($datatype, $class)
     {
-        if (!is_string($datatype) || (is_string($datatype) && 0 == strlen($datatype))) {
+        if (!\is_string($datatype) || (\is_string($datatype) && 0 == \strlen($datatype))) {
             throw new \InvalidArgumentException('$datatype should be a string and cannot be null or empty');
         }
 
-        if (!is_string($class) || (is_string($class) && 0 == strlen($class))) {
+        if (!\is_string($class) || (\is_string($class) && 0 == \strlen($class))) {
             throw new \InvalidArgumentException('$class should be a string and cannot be null or empty');
         }
 
@@ -155,7 +155,7 @@ class Literal
      */
     public static function deleteDatatypeMapping($datatype)
     {
-        if (!is_string($datatype) || (is_string($datatype) && 0 == strlen($datatype))) {
+        if (!\is_string($datatype) || (\is_string($datatype) && 0 == \strlen($datatype))) {
             throw new \InvalidArgumentException('$datatype should be a string and cannot be null or empty');
         }
 
@@ -173,8 +173,6 @@ class Literal
      * Given a PHP value, it will return an XSD datatype
      * URI for that value, for example:
      * http://www.w3.org/2001/XMLSchema#integer
-     *
-     * @param mixed $value
      *
      * @return string|null a URI for the datatype of $value
      */

--- a/lib/ParsedUri.php
+++ b/lib/ParsedUri.php
@@ -47,13 +47,13 @@ namespace EasyRdf;
 class ParsedUri
 {
     // For all URIs:
-    private $scheme = null;
-    private $fragment = null;
+    private $scheme;
+    private $fragment;
 
     // For hierarchical URIs:
-    private $authority = null;
-    private $path = null;
-    private $query = null;
+    private $authority;
+    private $path;
+    private $query;
 
     public const URI_REGEX = "|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?|";
 

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -49,13 +49,13 @@ abstract class Parser
 
     /** The current graph to insert triples into */
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     /** The format of the document currently being parsed */
-    protected $format = null;
+    protected $format;
 
     /** The base URI for the document currently being parsed */
-    protected $baseUri = null;
+    protected $baseUri;
 
     protected $tripleCount = 0;
 
@@ -92,8 +92,8 @@ abstract class Parser
      */
     protected function checkParseParams($graph, $data, $format, $baseUri)
     {
-        if (null == $graph || !\is_object($graph) ||
-            !($graph instanceof Graph)) {
+        if (null == $graph || !\is_object($graph)
+            || !($graph instanceof Graph)) {
             throw new \InvalidArgumentException('$graph should be an EasyRdf\Graph object and cannot be null');
         } else {
             $this->graph = $graph;

--- a/lib/Parser/Ntriples.php
+++ b/lib/Parser/Ntriples.php
@@ -57,7 +57,7 @@ class Ntriples extends Parser
      **/
     protected function unescapeString($str)
     {
-        if (false === strpos($str, '\\')) {
+        if (!str_contains($str, '\\')) {
             return $str;
         }
 
@@ -78,8 +78,8 @@ class Ntriples extends Parser
             return $str;
         }
 
-        while (preg_match('/\\\(U)([0-9A-F]{8})/', $str, $matches) ||
-               preg_match('/\\\(u)([0-9A-F]{4})/', $str, $matches)) {
+        while (preg_match('/\\\(U)([0-9A-F]{8})/', $str, $matches)
+               || preg_match('/\\\(u)([0-9A-F]{4})/', $str, $matches)) {
             $no = hexdec($matches[2]);
             if ($no < 128) {                // 0x80
                 $char = \chr($no);

--- a/lib/Parser/Rapper.php
+++ b/lib/Parser/Rapper.php
@@ -47,7 +47,7 @@ use EasyRdf\Utils;
  */
 class Rapper extends Json
 {
-    private $rapperCmd = null;
+    private $rapperCmd;
 
     public const MINIMUM_RAPPER_VERSION = '1.4.17';
 

--- a/lib/Parser/RdfXml.php
+++ b/lib/Parser/RdfXml.php
@@ -61,7 +61,7 @@ class RdfXml extends Parser
     private $sCount;
 
     /** @var object|resource|null */
-    private $xmlParser = null;
+    private $xmlParser;
 
     /**
      * Constructor
@@ -363,8 +363,8 @@ class RdfXml extends Parser
 
         /* any other attrs (skip rdf and xml, except rdf:_, rdf:value, rdf:Seq) */
         foreach ($a as $k => $v) {
-            if (((false === strpos($k, $this->xml)) && (false === strpos($k, $this->rdf))) ||
-                preg_match('/(\_[0-9]+|value|Seq|Bag|Alt|Statement|Property|List)$/', $k)) {
+            if (((!str_contains($k, $this->xml)) && (!str_contains($k, $this->rdf)))
+                || preg_match('/(\_[0-9]+|value|Seq|Bag|Alt|Statement|Property|List)$/', $k)) {
                 if (strpos($k, ':')) {
                     $this->add($s['value'], $k, $v, $s['type'], 'literal', null, $s['x_lang']);
                 }
@@ -493,9 +493,9 @@ class RdfXml extends Parser
         }
         /* any other attrs (skip rdf and xml) */
         foreach ($a as $k => $v) {
-            if (((false === strpos($k, $this->xml)) &&
-             (false === strpos($k, $this->rdf))) ||
-             preg_match('/(\_[0-9]+|value)$/', $k)) {
+            if (((!str_contains($k, $this->xml))
+             && (!str_contains($k, $this->rdf)))
+             || preg_match('/(\_[0-9]+|value)$/', $k)) {
                 if (strpos($k, ':')) {
                     if (!$o['value']) {
                         $o['value'] = $this->graph->newBNodeId();
@@ -550,7 +550,7 @@ class RdfXml extends Parser
             $name = $parts[1];
             if (!isset($this->nsp[$nsUri])) {
                 foreach ($this->nsp as $tmp1 => $tmp2) {
-                    if (0 === strpos($t, $tmp1)) {
+                    if (str_starts_with($t, $tmp1)) {
                         $nsUri = $tmp1;
                         $name = substr($t, \strlen($tmp1));
                         break;
@@ -731,7 +731,7 @@ class RdfXml extends Parser
                     $name = $parts[1];
                     if (!isset($this->nsp[$nsUri])) {
                         foreach ($this->nsp as $tmp1 => $tmp2) {
-                            if (0 === strpos($t, $tmp1)) {
+                            if (str_starts_with($t, $tmp1)) {
                                 $nsUri = $tmp1;
                                 $name = substr($t, \strlen($tmp1));
                                 break;

--- a/lib/Parser/Rdfa.php
+++ b/lib/Parser/Rdfa.php
@@ -378,7 +378,7 @@ class Rdfa extends Parser
             foreach (['rel', 'rev'] as $attr) {
                 if ($node->hasAttribute('property') && $node->hasAttribute($attr)) {
                     // Quick check in case there are no CURIEs to deal with.
-                    if (false === strpos($node->getAttribute($attr), ':')) {
+                    if (!str_contains($node->getAttribute($attr), ':')) {
                         $node->removeAttribute($attr);
                     } else {
                         // Only keep CURIEs.

--- a/lib/Parser/Turtle.php
+++ b/lib/Parser/Turtle.php
@@ -1189,22 +1189,22 @@ class Turtle extends Ntriples
         $o = \ord($c);
 
         return
-            $o >= 0x41 && $o <= 0x5A ||     // A-Z
-            $o >= 0x61 && $o <= 0x7A ||     // a-z
-            $o >= 0x00C0 && $o <= 0x00D6 ||
-            $o >= 0x00D8 && $o <= 0x00F6;
+            $o >= 0x41 && $o <= 0x5A     // A-Z
+            || $o >= 0x61 && $o <= 0x7A     // a-z
+            || $o >= 0x00C0 && $o <= 0x00D6
+            || $o >= 0x00D8 && $o <= 0x00F6;
     }
 
     /** @ignore */
     public static function isNameStartChar($c)
     {
         return
-            '\\' == $c ||
-            '_' == $c ||
-            ':' == $c ||
-            '%' == $c ||
-            ctype_digit($c) ||
-            self::isPrefixStartChar($c);
+            '\\' == $c
+            || '_' == $c
+            || ':' == $c
+            || '%' == $c
+            || ctype_digit($c)
+            || self::isPrefixStartChar($c);
     }
 
     /** @ignore */
@@ -1214,10 +1214,10 @@ class Turtle extends Ntriples
         $o = \ord($c);
 
         return
-            self::isNameStartChar($c) ||
-            $o >= 0x30 && $o <= 0x39 ||     // 0-9
-            '-' == $c ||
-            0x00B7 == $o;
+            self::isNameStartChar($c)
+            || $o >= 0x30 && $o <= 0x39     // 0-9
+            || '-' == $c
+            || 0x00B7 == $o;
     }
 
     /** @ignore */
@@ -1238,13 +1238,13 @@ class Turtle extends Ntriples
         $o = \ord($c);
 
         return
-            '_' == $c ||
-            $o >= 0x30 && $o <= 0x39 ||     // 0-9
-            self::isPrefixStartChar($c) ||
-            '-' == $c ||
-            0x00B7 == $o ||
-            $c >= 0x0300 && $c <= 0x036F ||
-            $c >= 0x203F && $c <= 0x2040;
+            '_' == $c
+            || $o >= 0x30 && $o <= 0x39     // 0-9
+            || self::isPrefixStartChar($c)
+            || '-' == $c
+            || 0x00B7 == $o
+            || $c >= 0x0300 && $c <= 0x036F
+            || $c >= 0x203F && $c <= 0x2040;
     }
 
     /** @ignore */
@@ -1253,8 +1253,8 @@ class Turtle extends Ntriples
         $o = \ord($c);
 
         return
-            $o >= 0x41 && $o <= 0x5A ||   // A-Z
-            $o >= 0x61 && $o <= 0x7A;     // a-z
+            $o >= 0x41 && $o <= 0x5A   // A-Z
+            || $o >= 0x61 && $o <= 0x7A;     // a-z
     }
 
     /** @ignore */
@@ -1263,9 +1263,9 @@ class Turtle extends Ntriples
         $o = \ord($c);
 
         return
-            $o >= 0x41 && $o <= 0x5A ||   // A-Z
-            $o >= 0x61 && $o <= 0x7A ||   // a-z
-            $o >= 0x30 && $o <= 0x39 ||   // 0-9
-            '-' == $c;
+            $o >= 0x41 && $o <= 0x5A   // A-Z
+            || $o >= 0x61 && $o <= 0x7A   // a-z
+            || $o >= 0x30 && $o <= 0x39   // 0-9
+            || '-' == $c;
     }
 }

--- a/lib/RdfNamespace.php
+++ b/lib/RdfNamespace.php
@@ -108,9 +108,9 @@ class RdfNamespace
         'xsd' => 'http://www.w3.org/2001/XMLSchema#',
     ];
 
-    private static $namespaces = null;
+    private static $namespaces;
 
-    private static $default = null;
+    private static $default;
 
     /** Counter for numbering anonymous namespaces */
     private static $anonymousNamespaceCount = 0;
@@ -346,7 +346,7 @@ class RdfNamespace
 
             $local_part = substr($uri, \strlen($long));
 
-            if (false !== strpos($local_part, '/')) {
+            if (str_contains($local_part, '/')) {
                 // we can't have '/' in local part
                 continue;
             }

--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -51,10 +51,10 @@ namespace EasyRdf;
 class Resource implements \ArrayAccess
 {
     /** The URI for this resource */
-    protected $uri = null;
+    protected $uri;
 
     /** The Graph that this resource belongs to */
-    protected $graph = null;
+    protected $graph;
 
     /** Constructor
      *
@@ -65,7 +65,7 @@ class Resource implements \ArrayAccess
      */
     public function __construct($uri, $graph = null)
     {
-        if (!is_string($uri) || (is_string($uri) && 0 == strlen($uri))) {
+        if (!\is_string($uri) || (\is_string($uri) && 0 == \strlen($uri))) {
             throw new \InvalidArgumentException('$uri should be a string and cannot be null or empty');
         }
 
@@ -198,7 +198,7 @@ class Resource implements \ArrayAccess
             }
 
             // PHP 8.1 info: https://php.watch/versions/8.1/html-entity-default-value-changes
-            $html .= ' '.htmlspecialchars($key, ENT_COMPAT).'="'.
+            $html .= ' '.htmlspecialchars($key, \ENT_COMPAT).'="'.
                          htmlspecialchars($value).'"';
         }
         $html .= '>'.htmlspecialchars($text).'</a>';

--- a/lib/Serialiser/Rapper.php
+++ b/lib/Serialiser/Rapper.php
@@ -51,7 +51,7 @@ use EasyRdf\Utils;
  */
 class Rapper extends Ntriples
 {
-    private $rapperCmd = null;
+    private $rapperCmd;
 
     /**
      * Constructor

--- a/lib/Serialiser/RdfXml.php
+++ b/lib/Serialiser/RdfXml.php
@@ -79,11 +79,11 @@ class RdfXml extends Serialiser
             $tag = "{$indent}<{$property}";
             if ($obj->isBNode()) {
                 if ($alreadyOutput || $rpcount > 1 || 0 == $pcount) {
-                    $tag .= ' rdf:nodeID="'.htmlspecialchars($obj->getBNodeId(), ENT_COMPAT).'"';
+                    $tag .= ' rdf:nodeID="'.htmlspecialchars($obj->getBNodeId(), \ENT_COMPAT).'"';
                 }
             } else {
                 if ($alreadyOutput || 1 != $rpcount || 0 == $pcount) {
-                    $tag .= ' rdf:resource="'.htmlspecialchars($obj->getURI(), ENT_COMPAT).'"';
+                    $tag .= ' rdf:resource="'.htmlspecialchars($obj->getURI(), \ENT_COMPAT).'"';
                 }
             }
 
@@ -105,17 +105,17 @@ class RdfXml extends Serialiser
                     $atrributes .= ' rdf:parseType="Literal"';
                     $value = (string) $obj;
                 } else {
-                    $datatype = htmlspecialchars($datatype, ENT_COMPAT);
+                    $datatype = htmlspecialchars($datatype, \ENT_COMPAT);
                     $atrributes .= " rdf:datatype=\"$datatype\"";
                 }
             } elseif ($obj->getLang()) {
                 $atrributes .= ' xml:lang="'.
-                               htmlspecialchars($obj->getLang(), ENT_COMPAT).'"';
+                               htmlspecialchars($obj->getLang(), \ENT_COMPAT).'"';
             }
 
             // Escape the value
             if (!isset($value)) {
-                $value = htmlspecialchars((string) $obj, ENT_COMPAT);
+                $value = htmlspecialchars((string) $obj, \ENT_COMPAT);
             }
 
             return "{$indent}<{$property}{$atrributes}>{$value}</{$property}>\n";
@@ -155,10 +155,10 @@ class RdfXml extends Serialiser
         $xml = "\n$indent<$type";
         if ($res->isBNode()) {
             if ($showNodeId) {
-                $xml .= ' rdf:nodeID="'.htmlspecialchars($res->getBNodeId(), ENT_COMPAT).'"';
+                $xml .= ' rdf:nodeID="'.htmlspecialchars($res->getBNodeId(), \ENT_COMPAT).'"';
             }
         } else {
-            $xml .= ' rdf:about="'.htmlspecialchars($res->getUri(), ENT_COMPAT).'"';
+            $xml .= ' rdf:about="'.htmlspecialchars($res->getUri(), \ENT_COMPAT).'"';
         }
         $xml .= ">\n";
 
@@ -241,9 +241,9 @@ class RdfXml extends Serialiser
             $prefix = trim($prefix);
 
             if (0 == \strlen($prefix)) {
-                $namespaceStr .= ' xmlns="'.htmlspecialchars($url, ENT_COMPAT).'"';
+                $namespaceStr .= ' xmlns="'.htmlspecialchars($url, \ENT_COMPAT).'"';
             } else {
-                $namespaceStr .= ' xmlns:'.$prefix.'="'.htmlspecialchars($url, ENT_COMPAT).'"';
+                $namespaceStr .= ' xmlns:'.$prefix.'="'.htmlspecialchars($url, \ENT_COMPAT).'"';
             }
         }
 

--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -52,12 +52,12 @@ use EasyRdf\Utils;
 class Client
 {
     /** The query/read address of the SPARQL Endpoint */
-    private $queryUri = null;
+    private $queryUri;
 
     private $queryUri_has_params = false;
 
     /** The update/write address of the SPARQL Endpoint */
-    private $updateUri = null;
+    private $updateUri;
 
     /** Create a new SPARQL endpoint client
      *
@@ -73,7 +73,7 @@ class Client
 
         $parseUrlResult = parse_url($queryUri, \PHP_URL_QUERY) ?? '';
 
-        if (0 < strlen($parseUrlResult)) {
+        if ('' !== $parseUrlResult) {
             $this->queryUri_has_params = true;
         } else {
             $this->queryUri_has_params = false;
@@ -308,8 +308,8 @@ class Client
         // Check for undefined prefixes
         $prefixes = '';
         foreach (RdfNamespace::namespaces() as $prefix => $uri) {
-            if (false !== strpos($query, "{$prefix}:") &&
-                false === strpos($query, "PREFIX {$prefix}:")
+            if (str_contains($query, "{$prefix}:")
+                  && !str_contains($query, "PREFIX {$prefix}:")
             ) {
                 $prefixes .= "PREFIX {$prefix}: <{$uri}>\n";
             }
@@ -416,7 +416,7 @@ class Client
     {
         list($content_type) = Utils::parseMimeType($response->getHeader('Content-Type'));
 
-        if (0 === strpos($content_type, 'application/sparql-results')) {
+        if (str_starts_with($content_type, 'application/sparql-results')) {
             $result = new Result($response->getBody(), $content_type);
 
             return $result;

--- a/lib/Sparql/Result.php
+++ b/lib/Sparql/Result.php
@@ -50,10 +50,10 @@ use EasyRdf\XMLParser;
 class Result extends \ArrayIterator
 {
     /** The SPARQL Results type (either 'boolean' or 'bindings') */
-    private $type = null;
+    private $type;
 
     /** The value of a boolean result */
-    private $boolean = null;
+    private $boolean;
 
     /** Keep track of the XML parser state */
     private $fields = [];

--- a/lib/TypeMapper.php
+++ b/lib/TypeMapper.php
@@ -62,7 +62,7 @@ class TypeMapper
      */
     public static function get($type)
     {
-        if (!is_string($type) || (is_string($type) && 0 == strlen($type))) {
+        if (!\is_string($type) || (\is_string($type) && 0 == \strlen($type))) {
             throw new \InvalidArgumentException('$type should be a string and cannot be null or empty');
         }
 
@@ -85,11 +85,11 @@ class TypeMapper
      */
     public static function set($type, $class)
     {
-        if (!is_string($type) || (is_string($type) && 0 == strlen($type))) {
+        if (!\is_string($type) || (\is_string($type) && 0 == \strlen($type))) {
             throw new \InvalidArgumentException('$type should be a string and cannot be null or empty');
         }
 
-        if (!is_string($class) || (is_string($class) && 0 == strlen($class))) {
+        if (!\is_string($class) || (\is_string($class) && 0 == \strlen($class))) {
             throw new \InvalidArgumentException('$class should be a string and cannot be null or empty');
         }
 
@@ -107,7 +107,7 @@ class TypeMapper
      */
     public static function delete($type)
     {
-        if (!is_string($type) || (is_string($type) && 0 == strlen($type))) {
+        if (!\is_string($type) || (\is_string($type) && 0 == \strlen($type))) {
             throw new \InvalidArgumentException('$type should be a string and cannot be null or empty');
         }
 
@@ -136,7 +136,7 @@ class TypeMapper
      */
     public static function setDefaultResourceClass($class)
     {
-        if (!is_string($class) || (is_string($class) && 0 == strlen($class))) {
+        if (!\is_string($class) || (\is_string($class) && 0 == \strlen($class))) {
             throw new \InvalidArgumentException('$class should be a string and cannot be null or empty');
         }
 

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -264,7 +264,7 @@ class Utils
              */
             $entries = [];
             foreach (array_merge([$command], $args) as $entry) {
-                if (is_string($entry)) {
+                if (\is_string($entry)) {
                     $entries[] = $entry;
                 }
             }
@@ -275,7 +275,7 @@ class Utils
             );
         } else {
             $fullCommand = escapeshellcmd($command);
-            if (is_string($args)) {
+            if (\is_string($args)) {
                 $fullCommand .= ' '.escapeshellcmd($args);
             }
         }

--- a/lib/XMLParser.php
+++ b/lib/XMLParser.php
@@ -48,16 +48,16 @@ class XMLParser extends \XMLReader
     public $path = [];
 
     /** Callback to call when a new element tag starts */
-    public $startElementCallback = null;
+    public $startElementCallback;
 
     /** Callback to call when a element tag ends */
-    public $endElementCallback = null;
+    public $endElementCallback;
 
     /** Callback to call when text or cdata is encountered */
-    public $textCallback = null;
+    public $textCallback;
 
     /** Callback to call when significant whitespace is encountered */
-    public $whitespaceCallback = null;
+    public $whitespaceCallback;
 
     /** Parse an XML string. Calls the callback methods
      *  when various nodes of an XML document are encountered

--- a/test/EasyRdf/Http/ClientTest.php
+++ b/test/EasyRdf/Http/ClientTest.php
@@ -48,7 +48,7 @@ class ClientTest extends TestCase
      *
      * @var Client
      */
-    protected $client = null;
+    protected $client;
 
     /**
      * Set up the test suite before each test

--- a/test/EasyRdf/Parser/ArcTest.php
+++ b/test/EasyRdf/Parser/ArcTest.php
@@ -44,10 +44,10 @@ use Test\TestCase;
 class ArcTest extends TestCase
 {
     /** @var Arc */
-    protected $parser = null;
+    protected $parser;
     /** @var Graph */
-    protected $graph = null;
-    protected $data = null;
+    protected $graph;
+    protected $data;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/JsonLdTest.php
+++ b/test/EasyRdf/Parser/JsonLdTest.php
@@ -52,10 +52,10 @@ use Test\TestCase;
 class JsonLdTest extends TestCase
 {
     /** @var JsonLd */
-    protected $parser = null;
+    protected $parser;
 
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/JsonTest.php
+++ b/test/EasyRdf/Parser/JsonTest.php
@@ -45,9 +45,9 @@ use Test\TestCase;
 class JsonTest extends TestCase
 {
     /** @var Json */
-    protected $parser = null;
+    protected $parser;
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -45,10 +45,10 @@ use Test\TestCase;
 class NtriplesTest extends TestCase
 {
     /** @var Ntriples */
-    protected $parser = null;
+    protected $parser;
     /** @var Graph */
-    protected $graph = null;
-    protected $nt_data = null;
+    protected $graph;
+    protected $nt_data;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/RapperTest.php
+++ b/test/EasyRdf/Parser/RapperTest.php
@@ -44,10 +44,10 @@ use Test\TestCase;
 class RapperTest extends TestCase
 {
     /** @var Rapper */
-    protected $parser = null;
+    protected $parser;
     /** @var Graph */
-    protected $graph = null;
-    protected $rdf_data = null;
+    protected $graph;
+    protected $rdf_data;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/RdfPhpTest.php
+++ b/test/EasyRdf/Parser/RdfPhpTest.php
@@ -47,10 +47,10 @@ use Test\TestCase;
 class RdfPhpTest extends TestCase
 {
     /** @var RdfPhp */
-    protected $parser = null;
+    protected $parser;
     /** @var Graph */
-    protected $graph = null;
-    protected $rdf_data = null;
+    protected $graph;
+    protected $rdf_data;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/RdfXmlTest.php
+++ b/test/EasyRdf/Parser/RdfXmlTest.php
@@ -46,10 +46,10 @@ use Test\TestCase;
 class RdfXmlTest extends TestCase
 {
     /** @var RdfXml */
-    protected $parser = null;
+    protected $parser;
     /** @var Graph */
-    protected $graph = null;
-    protected $rdf_data = null;
+    protected $graph;
+    protected $rdf_data;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/RdfaTest.php
+++ b/test/EasyRdf/Parser/RdfaTest.php
@@ -45,11 +45,11 @@ use Test\TestCase;
 class RdfaTest extends TestCase
 {
     /** @var Rdfa */
-    protected $rdfaParser = null;
+    protected $rdfaParser;
     /** @var Ntriples */
-    protected $ntriplesParser = null;
+    protected $ntriplesParser;
     protected $baseUri;
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Parser/TurtleTest.php
+++ b/test/EasyRdf/Parser/TurtleTest.php
@@ -52,10 +52,10 @@ Format::registerSerialiser('ntriples-array', NtriplesArray::class);
 class TurtleTest extends TestCase
 {
     /** @var Turtle */
-    protected $turtleParser = null;
+    protected $turtleParser;
 
     /** @var Ntriples */
-    protected $ntriplesParser = null;
+    protected $ntriplesParser;
 
     protected $baseUri;
 

--- a/test/EasyRdf/Serialiser/JsonLdTest.php
+++ b/test/EasyRdf/Serialiser/JsonLdTest.php
@@ -46,10 +46,10 @@ use Test\TestCase;
 class JsonLdTest extends TestCase
 {
     /** @var JsonLd */
-    protected $serialiser = null;
+    protected $serialiser;
 
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Serialiser/JsonTest.php
+++ b/test/EasyRdf/Serialiser/JsonTest.php
@@ -46,9 +46,9 @@ use Test\TestCase;
 class JsonTest extends TestCase
 {
     /** @var Json */
-    protected $serialiser = null;
+    protected $serialiser;
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Serialiser/NtriplesArray.php
+++ b/test/EasyRdf/Serialiser/NtriplesArray.php
@@ -86,14 +86,13 @@ class NtriplesArray extends Ntriples
         foreach ($graph->toRdfPhp() as $resource => $properties) {
             foreach ($properties as $property => $values) {
                 foreach ($values as $value) {
-                    array_push(
-                        $triples,
+                        $triples[] =
                         [
                             's' => $this->serialiseResource($resource),
                             'p' => '<'.$this->escapeString($property).'>',
                             'o' => $this->serialiseValue($value),
                         ]
-                    );
+                    ;
                 }
             }
         }

--- a/test/EasyRdf/Serialiser/NtriplesArray.php
+++ b/test/EasyRdf/Serialiser/NtriplesArray.php
@@ -86,13 +86,11 @@ class NtriplesArray extends Ntriples
         foreach ($graph->toRdfPhp() as $resource => $properties) {
             foreach ($properties as $property => $values) {
                 foreach ($values as $value) {
-                        $triples[] =
-                        [
-                            's' => $this->serialiseResource($resource),
-                            'p' => '<'.$this->escapeString($property).'>',
-                            'o' => $this->serialiseValue($value),
-                        ]
-                    ;
+                    $triples[] = [
+                        's' => $this->serialiseResource($resource),
+                        'p' => '<'.$this->escapeString($property).'>',
+                        'o' => $this->serialiseValue($value),
+                    ];
                 }
             }
         }

--- a/test/EasyRdf/Serialiser/NtriplesTest.php
+++ b/test/EasyRdf/Serialiser/NtriplesTest.php
@@ -49,9 +49,9 @@ use Test\TestCase;
 class NtriplesTest extends TestCase
 {
     /** @var Ntriples */
-    protected $serialiser = null;
+    protected $serialiser;
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Serialiser/RdfPhpTest.php
+++ b/test/EasyRdf/Serialiser/RdfPhpTest.php
@@ -45,9 +45,9 @@ use Test\TestCase;
 class RdfPhpTest extends TestCase
 {
     /** @var RdfPhp */
-    protected $serialiser = null;
+    protected $serialiser;
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/EasyRdf/Serialiser/RdfXmlTest.php
+++ b/test/EasyRdf/Serialiser/RdfXmlTest.php
@@ -49,9 +49,9 @@ use Test\TestCase;
 class RdfXmlTest extends TestCase
 {
     /** @var RdfXml */
-    protected $serialiser = null;
+    protected $serialiser;
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     public static function setUpBeforeClass(): void
     {

--- a/test/EasyRdf/Serialiser/TurtleTest.php
+++ b/test/EasyRdf/Serialiser/TurtleTest.php
@@ -48,9 +48,9 @@ use Test\TestCase;
 class TurtleTest extends TestCase
 {
     /** @var Turtle */
-    protected $serialiser = null;
+    protected $serialiser;
     /** @var Graph */
-    protected $graph = null;
+    protected $graph;
 
     protected function setUp(): void
     {

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -27,7 +27,7 @@ class TestCase extends FrameworkTestCase
      */
     public static function assertClass($class, $object)
     {
-        self::assertSame($class, \get_class($object));
+        self::assertSame($class, $object::class);
     }
 
     /**

--- a/test/examples/SerialiseTest.php
+++ b/test/examples/SerialiseTest.php
@@ -75,7 +75,7 @@ class SerialiseTest extends TestCase
         );
         $this->assertStringContainsString('<title>EasyRdf Serialiser Example</title>', $output);
 
-        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
+        if (version_compare(\PHP_VERSION, '8.1.0', '>=')) {
             $this->assertStringContainsString('value&#039; =&gt; &#039;http://xmlns.com/foaf/0.1/Person', $output);
         } else {
             $this->assertStringContainsString("'value' =&gt; 'http://xmlns.com/foaf/0.1/Person',", $output);


### PR DESCRIPTION
Reason to use 8.0.0 as minimum PHP version is extended effort to maintain PHP 7.x compatibility as well as blocking new changes like #25 (which require PHP 8.0+).