### PR TITLE
PHP 8.3 support

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['8.0', '8.1', '8.2']
+                php-versions: ['8.0', '8.1', '8.2', '8.3']
 
         steps:
             -   name: Checkout
@@ -38,7 +38,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['8.0', '8.1', '8.2']
+                php-versions: ['8.0', '8.1', '8.2', '8.3']
 
         steps:
             -   name: Checkout

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/bootstrap.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/bootstrap.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false"
+displayDetailsOnTestsThatTriggerDeprecations="true">
   <coverage/>
-  <php>
-    <!--
-        Fix for coverage report causing Seg Fault
-        (see https://bugs.php.net/bug.php?id=53976)
-      -->
-    <ini name="zend.enable_gc" value="0"/>
-  </php>
   <testsuites>
     <testsuite name="EasyRdf Library">
       <directory suffix="Test.php">tests/EasyRdf/</directory>

--- a/tests/EasyRdf/Serialiser/NtriplesTest.php
+++ b/tests/EasyRdf/Serialiser/NtriplesTest.php
@@ -313,7 +313,9 @@ class NtriplesTest extends TestCase
         $serializer = new Ntriples();
         // Include the NULL byte, a character, a control character,
         // a multibyte character, a character, and a character outside the BMP.
-        $string = utf8_encode(\chr(0).'a'.\chr(31)).'位'.utf8_encode(\chr(127)).'𐀐';
+        $string = mb_convert_encoding(\chr(0).'a'.\chr(31), 'UTF-8', 'ISO-8859-1');
+        $string .= '位'.mb_convert_encoding(\chr(127), 'UTF-8', 'ISO-8859-1').'𐀐';
+
         $literal = new Literal($string);
         $actual = $serializer->serialiseValue($literal);
         $this->assertEquals('"'.$string.'"', $actual);
@@ -329,7 +331,7 @@ class NtriplesTest extends TestCase
         // separate characters and not confused with multibyte characters.
         $string = "\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB\xCC\xCD\xCE\xCF";
         // Converts the string to 'ÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ'.
-        $string = utf8_encode($string);
+        $string = mb_convert_encoding($string, 'UTF-8', 'ISO-8859-1');
         $literal = new Literal($string);
         $actual = $serializer->serialiseValue($literal);
         $expected = '"ÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ"';


### PR DESCRIPTION
**Notes:**
* no adaptions required to support PHP 8.3
* made PHPUnit more verbose when deprecations appear
* replaced instances of utf8_encode to avoid deprecation warnings
* deprecation warnings from ARC2 vendor are being ignored