### PR TITLE
Prevent RdfNamespace::splitUri() from generating prefix:#fragment qnames

### DIFF
--- a/lib/RdfNamespace.php
+++ b/lib/RdfNamespace.php
@@ -346,8 +346,8 @@ class RdfNamespace
 
             $local_part = substr($uri, \strlen($long));
 
-            if (str_contains($local_part, '/')) {
-                // we can't have '/' in local part
+            // we can't have '/' or '#' in local part
+            if (str_contains($local_part, '/') || str_contains($local_part, '#')) {
                 continue;
             }
 
@@ -394,7 +394,7 @@ class RdfNamespace
      * @param string $uri             The full URI (eg 'http://xmlns.com/foaf/0.1/name')
      * @param bool   $createNamespace If true, a new namespace will be created
      *
-     * @return string|void The shortened URI (eg 'foaf:name') or null
+     * @return string|void The shortened URI (eg 'foaf:name') or void
      */
     public static function shorten($uri, $createNamespace = false)
     {

--- a/tests/EasyRdf/RdfNamespaceTest.php
+++ b/tests/EasyRdf/RdfNamespaceTest.php
@@ -683,4 +683,16 @@ class RdfNamespaceTest extends TestCase
             RdfNamespace::shorten('http://example.org/bar/baz')
         );
     }
+
+    /**
+     * URIs with fragments can only be shortened if the '#' character
+     * is part of the prefix. `prefix:[...]#fragment` is not a valid result
+     */
+    public function testNoShortFragment()
+    {
+        RdfNamespace::set('ex', 'http://example.org/');
+
+        $this->assertNull(RdfNamespace::shorten('http://example.org/foo#bar'));
+        $this->assertNull(RdfNamespace::shorten('http://example.org/#quack'));
+    }
 }

--- a/tests/EasyRdf/Serialiser/TurtleTest.php
+++ b/tests/EasyRdf/Serialiser/TurtleTest.php
@@ -653,13 +653,26 @@ class TurtleTest extends TestCase
     public function testSerialiseShortenableResource()
     {
         RdfNamespace::set('example', 'http://example.com/');
-        $joe = $this->graph->resource('http://example.com/joe#me');
+        $joe = $this->graph->resource('http://example.com/joe');
         $joe->add('rdf:type', 'foaf:Person');
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
             "@prefix example: <http://example.com/> .\n\n".
-            "example:joe#me a \"foaf:Person\" .\n",
+            "example:joe a \"foaf:Person\" .\n",
+            $turtle
+        );
+    }
+
+    public function testSerialiseUnshortenableResource()
+    {
+        RdfNamespace::set('example', 'http://example.com/');
+        $joe = $this->graph->resource('http://example.com/joe#me');
+        $joe->add('rdf:type', 'foaf:Person');
+
+        $turtle = $this->serialiser->serialise($this->graph, 'turtle');
+        $this->assertSame(
+            "<http://example.com/joe#me> a \"foaf:Person\" .\n",
             $turtle
         );
     }


### PR DESCRIPTION
This is a port of the pull request https://github.com/easyrdf/easyrdf/pull/404.

Author: @nevali

Quote from original PR:

> it's possible to coax EasyRdf\RdfNamespace::splitUri() into generating a qname in the form prefix:#fragment, which is not valid, for example by defining a namespace as https://www.example.com/foo/ and then referring to https://www.example.com/foo/#bar; this fix prevents that

I only made a few refinements. 

@nevali: It is good to go from my side. Would you like to comment or change anything?