### PR TITLE
Reach PHPStan level 5

### DIFF
--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -1265,7 +1265,7 @@ class Graph
      *
      * @param string $resource
      *
-     * @return array Array of full URIs
+     * @return array<string> Array of full URIs
      */
     public function propertyUris($resource)
     {

--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -426,7 +426,7 @@ class Client
                 } else {
                     $uri['query'] = '';
                 }
-                $uri['query'] .= http_build_query($this->paramsGet, null, '&');
+                $uri['query'] .= http_build_query($this->paramsGet, '', '&');
             }
 
             $headers = $this->prepareHeaders($uri['host'], $port);

--- a/lib/Http/Response.php
+++ b/lib/Http/Response.php
@@ -316,7 +316,7 @@ class Response
             }
         }
 
-        return new self($status, $headers, $body, $version, $message);
+        return new self((int) $status, $headers, $body, $version, $message);
     }
 
     /**

--- a/lib/Parser/RdfXml.php
+++ b/lib/Parser/RdfXml.php
@@ -91,9 +91,9 @@ class RdfXml extends Parser
             $parser = xml_parser_create_ns('UTF-8', '');
             xml_parser_set_option($parser, \XML_OPTION_SKIP_WHITE, 0);
             xml_parser_set_option($parser, \XML_OPTION_CASE_FOLDING, 0);
-            xml_set_element_handler($parser, 'startElementHandler', 'endElementHandler');
-            xml_set_character_data_handler($parser, 'cdataHandler');
-            xml_set_start_namespace_decl_handler($parser, 'newNamespaceHandler');
+            xml_set_element_handler($parser, [$this, 'startElementHandler'], [$this, 'endElementHandler']);
+            xml_set_character_data_handler($parser, [$this, 'cdataHandler']);
+            xml_set_start_namespace_decl_handler($parser, [$this, 'newNamespaceHandler']);
             xml_set_object($parser, $this);
             $this->xmlParser = $parser;
         }

--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -507,7 +507,7 @@ class Resource implements \ArrayAccess
      *
      * This method will return an empty array if the resource has no properties.
      *
-     * @return array Array of full URIs
+     * @return array<string> Array of full URIs
      */
     public function propertyUris()
     {

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -318,7 +318,6 @@ class Turtle extends Serialiser
     {
         $turtle = '';
         foreach ($graph->resources() as $resource) {
-            /** @var \EasyRdf\Resource */
             // If the resource has no properties - don't serialise it
             $properties = $resource->propertyUris();
             if (0 == \count($properties)) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,7 @@ parameters:
     fileExtensions:
         - php
 
-    level: 4
+    level: 5
 
     paths:
         - examples

--- a/tests/EasyRdf/Http/ClientTest.php
+++ b/tests/EasyRdf/Http/ClientTest.php
@@ -274,6 +274,28 @@ class ClientTest extends TestCase
     }
 
     /**
+     * This test covers the change from
+     *
+     *      $uri['query'] .= http_build_query($this->paramsGet, null, '&');
+     *
+     * to
+     *
+     *      $uri['query'] .= http_build_query($this->paramsGet, '', '&');
+     *
+     * Without the change a deprecation warning would be thrown.
+     */
+    public function testRequestGetParamsGiven(): void
+    {
+        $this->client->setParameterGet('foo', 'bar');
+
+        $response = $this->client->request();
+
+        // note: no real request was sent
+
+        $this->assertEquals(200, $response->getStatus());
+    }
+
+    /**
      * Test for issue #271
      *
      * Test approach was to first trigger the error with the following code and


### PR DESCRIPTION
With PHPStan level 5 we got the following:

```
   0. basic checks, unknown classes, unknown functions, unknown methods 
      called on $this, wrong number of arguments passed to those methods and functions, 
      always undefined variables
   1. possibly undefined variables, unknown magic methods and properties on classes with __call and __get
   2. unknown methods checked on all expressions (not just $this), validating PHPDocs
   3. return types, types assigned to properties
   4. basic dead code checking - always false instanceof and other type checks, 
      dead else branches, unreachable code after return; etc.
X  5. checking types of arguments passed to methods and functions
```

For more information: https://phpstan.org/user-guide/rule-levels