### PR TITLE
Bring back dependency suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,10 @@
         "lib-libxml" : "*",
         "sweetrdf/rdf-helpers": "^2.0"
     },
+    "suggest": {
+        "ml/json-ld": "^1.0",
+        "semsol/arc2": "^3"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "ml/json-ld": "^1.0",


### PR DESCRIPTION
As certain parts of the code will throw when these dependencies are not installed they need to be suggested. This was, other tools, such as composer-unused, can correctly detect that when installed it is due to the suggestion from this package.