### PR TITLE
Issue/52 whitespace before langtag

### DIFF
--- a/lib/Parser/Turtle.php
+++ b/lib/Parser/Turtle.php
@@ -554,6 +554,8 @@ class Turtle extends Ntriples
     {
         $label = $this->parseQuotedString();
 
+        $this->skipWSC();
+
         // Check for presence of a language tag or datatype
         $c = $this->peek();
 

--- a/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.out
+++ b/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.out
@@ -1,1 +1,2 @@
 <http://example.org/#a> <http://www.w3.org/2000/01/rdf-schema#label> "Test"@en .
+<http://example.org/#a> <http://www.w3.org/2000/01/rdf-schema#label> "Test"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.out
+++ b/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.out
@@ -1,0 +1,1 @@
+<http://example.org/#a> <http://www.w3.org/2000/01/rdf-schema#label> "Test"@en .

--- a/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.ttl
+++ b/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.ttl
@@ -1,5 +1,9 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <http://example.org/#> .
 
 # Allow whitespace between literal and language tag
 :a rdfs:label "Test"      @en .
+
+# Allow whitespace between literal and datatype IRI
+:a rdfs:label "Test"      ^^xs:string .

--- a/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.ttl
+++ b/test/fixtures/turtle/gh52-sweetrdf-whitespace-langtag.ttl
@@ -1,0 +1,5 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix : <http://example.org/#> .
+
+# Allow whitespace between literal and language tag
+:a rdfs:label "Test"      @en .

--- a/tests/EasyRdf/Parser/TurtleTest.php
+++ b/tests/EasyRdf/Parser/TurtleTest.php
@@ -578,4 +578,13 @@ class TurtleTest extends TestCase
         $this->assertEquals(14, $triple_count);
         */
     }
+
+    /**
+     * @see https://github.com/sweetrdf/easyrdf/issues/52
+     * Notice this is an issue reported in the sweetrdf/easyrdf fork
+     */
+    public function testIssue52()
+    {
+        $this->turtleTestCase('gh52-sweetrdf-whitespace-langtag');
+    }
 }


### PR DESCRIPTION
Allow whitespace between quoted string literal and langtag or datatype.

Fixes #52