### PR TITLE
Issue/51 dot in name

### DIFF
--- a/lib/Parser/Turtle.php
+++ b/lib/Parser/Turtle.php
@@ -940,6 +940,11 @@ class Turtle extends Ntriples
                 }
                 $c = $this->read();
             }
+
+            // Last char of name must not be a dot
+            if (mb_substr($localName, -1) === '.') {
+                throw new Exception("Turtle Parse Error: last character of QName must not be a dot", $this->line, $this->column - 1);
+            }
         }
 
         // Unread last character

--- a/lib/Parser/Turtle.php
+++ b/lib/Parser/Turtle.php
@@ -1217,6 +1217,7 @@ class Turtle extends Ntriples
             self::isNameStartChar($c)
             || $o >= 0x30 && $o <= 0x39     // 0-9
             || '-' == $c
+            || '.' == $c                    // dots are allowed in the middle of a name, not as start char
             || 0x00B7 == $o;
     }
 

--- a/test/fixtures/turtle/bad-07.ttl
+++ b/test/fixtures/turtle/bad-07.ttl
@@ -1,4 +1,3 @@
 # paths are not in turtle
 @prefix : <http://example.org/stuff/1.0/> .
-:a.:b.:c .
 :a^:b^:c .

--- a/test/fixtures/turtle/gh51-sweetrdf-dot-in-name-bad.ttl
+++ b/test/fixtures/turtle/gh51-sweetrdf-dot-in-name-bad.ttl
@@ -1,0 +1,9 @@
+@prefix : <http://example.org/#> .
+
+# A dot can't be the first nor the last character of the "after the semicolon part of a prefixed name" but is allowed in the middle
+# See https://www.w3.org/TR/turtle/#grammar-production-PN_LOCAL
+# See https://github.com/sweetrdf/easyrdf/issues/51
+# The triples below should not parse!
+:SubjectWithEndDot. :predicate :Object .
+:Subject :predicateWithEndDot. :Object .
+:Subject :predicate :ObjectWithEndDot. .

--- a/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.out
+++ b/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.out
@@ -1,0 +1,2 @@
+<http://example.org/#Subject.WithADot> <http://example.org/#predicate.withADot> <http://example.org/#Object.WithADot> .
+<http://example.org/#Subject.With.Dots> <http://example.org/#predicate.with.dots> <http://example.org/#Object.With.Dots> .

--- a/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.ttl
+++ b/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.ttl
@@ -1,0 +1,7 @@
+@prefix : <http://example.org/#> .
+
+# A dot can't be the first nor the last character of the "after the semicolon part of a prefixed name" but is allowed in the middle
+# See https://www.w3.org/TR/turtle/#grammar-production-PN_LOCAL
+# See https://github.com/sweetrdf/easyrdf/issues/51
+:Subject.WithADot :predicate.withADot :Object.WithADot .
+:Subject.With.Dots :predicate.with.dots :Object.With.Dots .

--- a/tests/EasyRdf/Parser/TurtleTest.php
+++ b/tests/EasyRdf/Parser/TurtleTest.php
@@ -434,7 +434,7 @@ class TurtleTest extends TestCase
         // paths are not in turtle
         $this->expectException('EasyRdf\Parser\Exception');
         $this->expectExceptionMessage(
-            'Turtle Parse Error: object for statement missing on line 3, column 5'
+            "Turtle Parse Error: expected an RDF value here, found '^' on line 3, column 3"
         );
         $this->parseTurtle('turtle/bad-07.ttl');
     }

--- a/tests/EasyRdf/Parser/TurtleTest.php
+++ b/tests/EasyRdf/Parser/TurtleTest.php
@@ -587,4 +587,14 @@ class TurtleTest extends TestCase
     {
         $this->turtleTestCase('gh51-sweetrdf-dot-in-name');
     }
+
+    public function testIssue51Bad()
+    {
+        // Test long literals with missing end
+        $this->expectException('EasyRdf\Parser\Exception');
+        $this->expectExceptionMessage(
+            'Turtle Parse Error: last character of QName must not be a dot on line 7, column 20'
+        );
+        $this->parseTurtle('turtle/gh51-sweetrdf-dot-in-name-bad.ttl');
+    }
 }

--- a/tests/EasyRdf/Parser/TurtleTest.php
+++ b/tests/EasyRdf/Parser/TurtleTest.php
@@ -578,4 +578,13 @@ class TurtleTest extends TestCase
         $this->assertEquals(14, $triple_count);
         */
     }
+
+    /**
+     * @see https://github.com/sweetrdf/easyrdf/issues/51
+     * Notice this is an issue reported in the sweetrdf/easyrdf fork
+     */
+    public function testIssue51()
+    {
+        $this->turtleTestCase('gh51-sweetrdf-dot-in-name');
+    }
 }


### PR DESCRIPTION
Allow dot in the middle of a QName.

Fixes #51 

Added tests to check for allowed usage of dot in middle of name and a test to prevent the dot as last character of a name.