### PR TITLE
Issue/51 dot last char

### DIFF
--- a/lib/Parser/Turtle.php
+++ b/lib/Parser/Turtle.php
@@ -948,7 +948,10 @@ class Turtle extends Ntriples
 
             // Last char of name must not be a dot
             if (mb_substr($localName, -1) === '.') {
-                throw new Exception("Turtle Parse Error: last character of QName must not be a dot", $this->line, $this->column - 1);
+                $localName = substr_replace($localName, '', -1);
+                $this->unread($c); // step back
+                $this->unread('.'); // return dot to input buffer
+                $c = $this->read(); // read, because below the unread($c) is done for all cases
             }
         }
 

--- a/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.out
+++ b/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.out
@@ -1,2 +1,3 @@
 <http://example.org/#Subject.WithADot> <http://example.org/#predicate.withADot> <http://example.org/#Object.WithADot> .
 <http://example.org/#Subject.With.Dots> <http://example.org/#predicate.with.dots> <http://example.org/#Object.With.Dots> .
+<http://example.org/#sub> <http://example.org/#pred> <http://example.org/#Object.WithADot> .

--- a/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.ttl
+++ b/test/fixtures/turtle/gh51-sweetrdf-dot-in-name.ttl
@@ -5,3 +5,6 @@
 # See https://github.com/sweetrdf/easyrdf/issues/51
 :Subject.WithADot :predicate.withADot :Object.WithADot .
 :Subject.With.Dots :predicate.with.dots :Object.With.Dots .
+
+# A dot as last char is not part of the name but parsed as statement ending
+:sub :pred :Object.WithADot.

--- a/tests/EasyRdf/Parser/TurtleTest.php
+++ b/tests/EasyRdf/Parser/TurtleTest.php
@@ -594,7 +594,7 @@ class TurtleTest extends TestCase
         // Test long literals with missing end
         $this->expectException('EasyRdf\Parser\Exception');
         $this->expectExceptionMessage(
-            'Turtle Parse Error: last character of QName must not be a dot on line 7, column 20'
+            'Turtle Parse Error: Illegal predicate type: literal on line 7, column 19'
         );
         $this->parseTurtle('turtle/gh51-sweetrdf-dot-in-name-bad.ttl');
     }


### PR DESCRIPTION
This PR addresses the comment made by @zozlak in https://github.com/sweetrdf/easyrdf/pull/57. Related to #51 

> The ending dot should not throw an error but be returned to the input buffer instead.

I've updated the QName parsing accordingly