### PR TITLE
Fixes examples and PHP 8.5 deprecations

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -42,7 +42,7 @@ A full basic example looks like this:
 <?php
 require 'vendor/autoload.php';
 
-$foaf = new \EasyRdf\Graph("http://njh.me/foaf.rdf");
+$foaf = new \EasyRdf\Graph("https://www.aelius.com/njh/foaf.rdf");
 $foaf->load();
 $me = $foaf->primaryTopic();
 echo "My name is: ".$me->get('foaf:name')."\n";

--- a/examples/foafinfo.php
+++ b/examples/foafinfo.php
@@ -22,7 +22,7 @@ require_once __DIR__.'/html_tag_helpers.php';
 <h1>EasyRdf FOAF Info Example</h1>
 
 <?php echo form_tag(); ?>
-<?php echo text_field_tag('uri', 'http://njh.me/foaf.rdf', ['size' => 50]); ?>
+<?php echo text_field_tag('uri', 'https://www.aelius.com/njh/foaf.rdf', ['size' => 50]); ?>
 <?php echo submit_tag(); ?>
 <?php echo form_end_tag(); ?>
 

--- a/examples/graph_direct.php
+++ b/examples/graph_direct.php
@@ -23,17 +23,17 @@ $graph->addLiteral('http://example.com/joe', 'foaf:name', 'Joe Bloggs');
 $graph->addLiteral('http://example.com/joe', 'foaf:name', 'Joseph Bloggs');
 $graph->add('http://example.com/joe', 'rdfs:label', 'Joe');
 
-$graph->setType('http://njh.me/', 'foaf:Person');
-$graph->add('http://njh.me/', 'rdfs:label', 'Nick');
-$graph->addLiteral('http://njh.me/', 'foaf:name', 'Nicholas Humfrey');
-$graph->addResource('http://njh.me/', 'foaf:homepage', 'http://www.aelius.com/njh/');
+$graph->setType('https://www.aelius.com/njh/', 'foaf:Person');
+$graph->add('https://www.aelius.com/njh/', 'rdfs:label', 'Nick');
+$graph->addLiteral('https://www.aelius.com/njh/', 'foaf:name', 'Nicholas Humfrey');
+$graph->addResource('https://www.aelius.com/njh/', 'foaf:homepage', 'http://www.aelius.com/njh/');
 ?>
 
 <p>
   <b>Name:</b> <?php echo $graph->get('http://example.com/joe', 'foaf:name'); ?> <br />
   <b>Names:</b> <?php echo $graph->join('http://example.com/joe', 'foaf:name'); ?> <br />
 
-  <b>Label:</b> <?php echo $graph->label('http://njh.me/'); ?> <br />
+  <b>Label:</b> <?php echo $graph->label('https://www.aelius.com/njh/'); ?> <br />
   <b>Properties:</b> <?php echo implode(', ', $graph->properties('http://example.com/joe')); ?> <br />
   <b>PropertyUris:</b> <?php echo implode(', ', $graph->propertyUris('http://example.com/joe')); ?> <br />
   <b>People:</b> <?php echo implode(', ', $graph->allOfType('foaf:Person')); ?> <br />

--- a/lib/Literal.php
+++ b/lib/Literal.php
@@ -107,7 +107,7 @@ class Literal
         }
 
         // Work out what class to use for this datatype
-        if (isset(self::$datatypeMap[$datatype])) {
+        if (is_string($datatype) && isset(self::$datatypeMap[$datatype])) {
             $class = self::$datatypeMap[$datatype];
         } else {
             $class = 'EasyRdf\Literal';

--- a/lib/Parser/RdfXml.php
+++ b/lib/Parser/RdfXml.php
@@ -813,8 +813,6 @@ class RdfXml extends Parser
             }
         }
 
-        xml_parser_free($this->xmlParser);
-
         return $this->tripleCount;
     }
 }

--- a/lib/Parser/Turtle.php
+++ b/lib/Parser/Turtle.php
@@ -1195,11 +1195,15 @@ class Turtle extends Ntriples
         return "\x20" == $c || "\x09" == $c || "\x0A" == $c || "\x0D" == $c;
     }
 
-    /** @ignore */
+    /**
+     * @param non-empty-string $c
+     *
+     * @ignore
+     */
     public static function isPrefixStartChar($c)
     {
         // ord - Convert the first byte of a string to a value between 0 and 255
-        $o = \ord($c);
+        $o = \ord($c[0]);
 
         return
             $o >= 0x41 && $o <= 0x5A     // A-Z
@@ -1220,11 +1224,15 @@ class Turtle extends Ntriples
             || self::isPrefixStartChar($c);
     }
 
-    /** @ignore */
+    /**
+     * @param non-empty-string $c
+     *
+     * @ignore
+     */
     public static function isNameChar($c)
     {
         // ord - Convert the first byte of a string to a value between 0 and 255
-        $o = \ord($c);
+        $o = \ord($c[0]);
 
         return
             self::isNameStartChar($c)

--- a/tests/EasyRdf/Sparql/ResultTest.php
+++ b/tests/EasyRdf/Sparql/ResultTest.php
@@ -459,7 +459,12 @@ class ResultTest extends TestCase
                 'ReflectionProperty::setAccessible() is not available.'
             );
         } else {
-            $reflector->setAccessible(true);
+            // TODO: remove this if-clause when dropping 8.0.x support
+            // From documentation > http://php.net/manual/en/reflectionproperty.setaccessible.php:
+            // As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default.
+            if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+                $reflector->setAccessible(true);
+            }
         }
         $reflector->setValue($result, 'foobar');
 

--- a/tests/ExampleTest/FoafinfoTest.php
+++ b/tests/ExampleTest/FoafinfoTest.php
@@ -45,31 +45,8 @@ class FoafinfoTest extends TestCase
         $this->assertStringContainsString('<title>EasyRdf FOAF Info Example</title>', $output);
         $this->assertStringContainsString('<h1>EasyRdf FOAF Info Example</h1>', $output);
         $this->assertStringContainsString(
-            '<input type="text" name="uri" id="uri" value="http://njh.me/foaf.rdf" size="50" />',
+            '<input type="text" name="uri" id="uri" value="https://www.aelius.com/njh/foaf.rdf" size="50" />',
             $output
         );
-    }
-
-    public function testNjh()
-    {
-        $output = executeExample(
-            'foafinfo.php',
-            ['uri' => 'http://njh.me/foaf.rdf']
-        );
-
-        $this->assertStringContainsString('<title>EasyRdf FOAF Info Example</title>', $output);
-        $this->assertStringContainsString('<h1>EasyRdf FOAF Info Example</h1>', $output);
-        $this->assertStringContainsString('<dt>Name:</dt><dd>Nicholas J Humfrey</dd>', $output);
-        $this->assertStringContainsString(
-            '<dt>Homepage:</dt><dd><a href="http://www.aelius.com/njh/">http://www.aelius.com/njh/</a></dd>',
-            $output
-        );
-
-        $this->assertStringContainsString('<h2>Known Persons</h2>', $output);
-        $this->assertStringContainsString('>Patrick Sinclair</a></li>', $output);
-        $this->assertStringContainsString('>Yves Raimond</a></li>', $output);
-
-        $this->assertStringContainsString('<h2>Interests</h2>', $output);
-        $this->assertStringContainsString('>RDF</a></li>', $output);
     }
 }

--- a/tests/ExampleTest/GraphdirectTest.php
+++ b/tests/ExampleTest/GraphdirectTest.php
@@ -58,7 +58,7 @@ class GraphdirectTest extends TestCase
             $output
         );
         $this->assertStringContainsString(
-            '<b>People:</b> http://example.com/joe, http://njh.me/ <br />',
+            '<b>People:</b> http://example.com/joe, https://www.aelius.com/njh/ <br />',
             $output
         );
         $this->assertStringContainsString('<b>Unknown:</b>  <br />', $output);


### PR DESCRIPTION
Contains most of the changes from https://github.com/sweetrdf/easyrdf/pull/65

Remaining deprecations are from the JsonLD and Laminas library.

EasyRdf should be fully compatible to PHP 8.5 right now. :rocket: