### PR TITLE
Fix tests that failed due to changes in DBPedia data

### DIFF
--- a/tests/ExampleTest/BasicSparqlTest.php
+++ b/tests/ExampleTest/BasicSparqlTest.php
@@ -46,7 +46,7 @@ class BasicSparqlTest extends TestCase
         $this->assertStringContainsString('<h1>EasyRdf Basic Sparql Example</h1>', $output);
         $this->assertStringContainsString('<h2>List of countries</h2>', $output);
         $this->assertStringContainsString(
-            '<li><a href="http://dbpedia.org/resource/1_in_60_rule">1 in 60 rule</a></li>',
+            '<li><a href="http://dbpedia.org/resource/3G_countries">3G countries</a></li>',
             $output
         );
         $this->assertMatchesRegularExpressionPolyfill('|Total number of countries: (\d+)|', $output);

--- a/tests/ExampleTest/SparqlqueryformTest.php
+++ b/tests/ExampleTest/SparqlqueryformTest.php
@@ -72,8 +72,8 @@ class SparqlqueryformTest extends TestCase
                     '} ORDER BY ?label LIMIT 5',
             ]
         );
-        $this->assertStringContainsString('>http://dbpedia.org/resource/10th_century</a>', $output);
-        $this->assertStringContainsString('>&quot;10th century&quot;@en</span>', $output);
+        $this->assertStringContainsString('>http://dbpedia.org/resource/3G_countries</a>', $output);
+        $this->assertStringContainsString('>&quot;3G countries&quot;@en</span>', $output);
     }
 
     public function testDbpediaCountriesText()
@@ -92,7 +92,7 @@ class SparqlqueryformTest extends TestCase
             ]
         );
 
-        $this->assertStringContainsString('| http://dbpedia.org/resource/10th_century', $output);
-        $this->assertStringContainsString('| &quot;10th century&quot;@en', $output);
+        $this->assertStringContainsString('| http://dbpedia.org/resource/3G_countries', $output);
+        $this->assertStringContainsString('| &quot;3G countries&quot;@en', $output);
     }
 }


### PR DESCRIPTION
While setting up my development environment to work on #67, I noticed that three PHPUnit tests are failing. After some digging I think I found the cause: these three tests are executing SPARQL queries against DBPedia and expecting specific entities in the results. It looks like DBPedia data has changed a bit and the expected entities are no longer returned, causing the tests to fail.

It's a bit funny because the SPARQL queries are targeting countries, but the tests are expecting the query result to contain entities that in my mind are definitely not countries at all ("1 in 60 rule" and "10th century"). So they were relying on bad data within DBPedia! I changed all of these to expect "3G countries" instead, which is still typed as a dbo:Country in DBPedia and thus part of the query result. (Pedantic me says that a group of countries is **not** a country in itself, but that's how it is represented currently in DBPedia. And since the queries have a LIMIT 10 and sort alphabetically by label, none of the returned 10 entities are in fact countries in a strict sense, so I simply picked one of them.)

Before this PR:

    Tests: 1413, Assertions: 2808, Failures: 3, Skipped: 16, Incomplete: 15.

After this PR:

    Tests: 1413, Assertions: 2811, Skipped: 16, Incomplete: 15.